### PR TITLE
Fix error AuthenticationError: , InvalidClientIdError: ... Tenant ... not found

### DIFF
--- a/recipes/utilities.py
+++ b/recipes/utilities.py
@@ -35,7 +35,7 @@ class Configuration:
             self.subscription_id = encode(conf['subscription_id'])
             self.aad_client_id = encode(conf['aad_client_id'])
             self.aad_secret_key = encode(conf['aad_secret'])
-            self.aad_token_uri = 'https://login.windows-ppe.net/{0}/oauth2/token'.format(encode(conf['aad_tenant']))
+            self.aad_token_uri = 'https://login.microsoftonline.com/{0}/oauth2/token'.format(encode(conf['aad_tenant']))
             self.location = encode(conf['location'])
             self.url = encode(conf['base_url'])
             self.resource_group = encode(conf['resource_group'])


### PR DESCRIPTION
Script failed to connect with old value aad_token_uri = 'https://login.windows-ppe.net... with 
AuthenticationError: , InvalidClientIdError: (invalid_request) AADSTS90002: Tenant 72f988bf-86f1-41af-91ab-2d7cd011db47 not found. This may happen if there are no active subscriptions for the tenant. Check with your subscription administrator.
Trace ID: 273b117e-cda4-4295-b83b-0328ad040500
Correlation ID: 1b17d3fa-e0d5-47b8-a307-482ab43f47f8
Timestamp: 2018-03-06 08:38:40Z