### PR TITLE
Fix CIFAR 10 data prepare script filename.

### DIFF
--- a/recipes/CNTK/CNTK-GPU-Python-Distributed-Infiniband/CNTK-GPU-Python-Distributed-Infiniband.ipynb
+++ b/recipes/CNTK/CNTK-GPU-Python-Distributed-Infiniband/CNTK-GPU-Python-Distributed-Infiniband.ipynb
@@ -219,7 +219,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will create a folder on Azure File Share containing a copy of [TrainResNet_CIFAR10_Distributed.py](https://github.com/Microsoft/CNTK/blob/v2.3.1/Examples/Image/Classification/ResNet/Python/TrainResNet_CIFAR10_Distributed.py), [TrainResNet_CIFAR10.py](https://github.com/Microsoft/CNTK/blob/v2.3.1/Examples/Image/Classification/ResNet/Python/TrainResNet_CIFAR10.py) and [CIFA-resnet_models.py](https://github.com/Microsoft/CNTK/blob/v2.3.1/Examples/Image/Classification/ResNet/Python/resnet_models.py). "
+    "We will create a folder on Azure File Share containing a copy of [TrainResNet_CIFAR10_Distributed.py](https://github.com/Microsoft/CNTK/blob/v2.3.1/Examples/Image/Classification/ResNet/Python/TrainResNet_CIFAR10_Distributed.py), [TrainResNet_CIFAR10.py](https://github.com/Microsoft/CNTK/blob/v2.3.1/Examples/Image/Classification/ResNet/Python/TrainResNet_CIFAR10.py) and [CIFAR-resnet_models.py](https://github.com/Microsoft/CNTK/blob/v2.3.1/Examples/Image/Classification/ResNet/Python/resnet_models.py). "
    ]
   },
   {
@@ -336,7 +336,7 @@
    "source": [
     "### Configure Job\n",
     "- The job will use `batchaitraining/cntk:2.3-gpu-1bitsgd-py36-cuda8-cudnn6-intelmpi` container that is built based on [dockerfile](./dockerfile)\n",
-    "- Will use job preparation task to execute job prreparation script (jobprep_cntk_distributed_ib.sh). The CIFA-10 dataset will be downloaded and processed on compute nodes locally (under ```$AZ_BATCHAI_JOB_TEMP``` directory);\n",
+    "- Will use job preparation task to execute job prreparation script (jobprep_cntk_distributed_ib.sh). The CIFAR-10 dataset will be downloaded and processed on compute nodes locally (under ```$AZ_BATCHAI_JOB_TEMP``` directory);\n",
     "- Will use configured previously input and output directories;\n",
     "- Will run TrainResNet_CIFAR10_Distributed.py providing CIFAR-10 Dataset path as the first parameter and desired mode output as the second one. \n",
     "- Will set ```process_count``` to 8, so that all 8 GPUs from 2 NC24r nodes will be used;\n",

--- a/recipes/CNTK/CNTK-GPU-Python-Distributed-Infiniband/cli-instructions.md
+++ b/recipes/CNTK/CNTK-GPU-Python-Distributed-Infiniband/cli-instructions.md
@@ -3,7 +3,7 @@ Please follow [instructions](/recipes/Readme.md) to install Azure CLI 2.0, confi
 
 ### Data Deployment
 
-- Download ConvNet_CIFAR10_DataAug_Distributed.py, ConvNet_CIFAR10_DataAug.py and CIFA-10_data_prepare.sh into the current folder:
+- Download ConvNet_CIFAR10_DataAug_Distributed.py, ConvNet_CIFAR10_DataAug.py and CIFAR-10_data_prepare.sh into the current folder:
 
 For GNU/Linux users:
 
@@ -58,7 +58,7 @@ az batchai cluster create -n nc24r -s Standard_NC24r --min 2 --max 2 --afs-name 
 The job creation parameters are in [job.json](./job.json):
 
 - The job will use `batchaitraining/cntk:2.3-gpu-1bitsgd-py36-cuda8-cudnn6-intelmpi` container that is built based on [dockerfile](./dockerfile)
-- Will use job preparation task to execute job preparation script (jobprep_cntk_distributed_ib.sh). The CIFA-10 dataset will be downloaded and processed on compute nodes locally (under ```$AZ_BATCHAI_JOB_TEMP``` directory);
+- Will use job preparation task to execute job preparation script (jobprep_cntk_distributed_ib.sh). The CIFAR-10 dataset will be downloaded and processed on compute nodes locally (under ```$AZ_BATCHAI_JOB_TEMP``` directory);
 - Will use configured previously input and output directories;
 - Will run TrainResNet_CIFAR10_Distributed.py providing CIFAR-10 Dataset path as the first parameter and desired mode output as the second one.
 - Will set ```processCount``` to 8, so that all 8 GPUs from 2 NC24r nodes will be used;

--- a/recipes/CNTK/CNTK-GPU-Python-Distributed/CNTK-GPU-Python-Distrbuted.ipynb
+++ b/recipes/CNTK/CNTK-GPU-Python-Distributed/CNTK-GPU-Python-Distrbuted.ipynb
@@ -311,7 +311,7 @@
    "source": [
     "### Configure Job\n",
     "- The job will use `microsoft/cntk:2.1-gpu-python3.5-cuda8.0-cudnn6.0` container.\n",
-    "- Will use job preparation task to execute CIFAR-10 data preparation script (CIFA-10_data_prepare.sh). The data set will be downloaded and processed on compute nodes locally (under AZ_BATCHAI_JOB_TEMP directory);\n",
+    "- Will use job preparation task to execute CIFAR-10 data preparation script (CIFAR-10_data_prepare.sh). The data set will be downloaded and processed on compute nodes locally (under AZ_BATCHAI_JOB_TEMP directory);\n",
     "- Will use configured previously input and output directories;\n",
     "- Will run ConvNet_CIFAR10_DataAug_Distributed.py providing CIFAR-10 Dataset path as the first parameter and desired mode output as the second one. \n",
     "- For illustration purpose, we will only run 5 epoches\n",

--- a/recipes/CNTK/CNTK-GPU-Python-Distributed/cli-instructions.md
+++ b/recipes/CNTK/CNTK-GPU-Python-Distributed/cli-instructions.md
@@ -18,13 +18,13 @@ az storage account create -n <storage account name> --sku Standard_LRS -l eastus
 
 ### Data Deployment
 
-- Download ConvNet_CIFAR10_DataAug_Distributed.py and CIFA-10_data_prepare.sh into the current folder:
+- Download ConvNet_CIFAR10_DataAug_Distributed.py and CIFAR-10_data_prepare.sh into the current folder:
 
 For GNU/Linux users:
 
 ```sh
 wget "https://raw.githubusercontent.com/Azure/BatchAI/master/recipes/CNTK/CNTK-GPU-Python-Distributed/ConvNet_CIFAR10_DataAug_Distributed.py?token=AcZzrbN1I34RrKn8MPnn5_dfy86I-XEIks5Z4cfswA%3D%3D" -O ConvNet_CIFAR10_DataAug_Distributed.py
-wget "https://raw.githubusercontent.com/Azure/BatchAI/master/recipes/CNTK/CNTK-GPU-Python-Distributed/CIFAR-10_data_prepare.sh?token=AcZzrdr1tTQK_Gr7EdVXvg-sUarpWMqnks5Z4chYwA%3D%3D" -O CIFA-10_data_prepare.sh
+wget "https://raw.githubusercontent.com/Azure/BatchAI/master/recipes/CNTK/CNTK-GPU-Python-Distributed/CIFAR-10_data_prepare.sh?token=AcZzrdr1tTQK_Gr7EdVXvg-sUarpWMqnks5Z4chYwA%3D%3D" -O CIFAR-10_data_prepare.sh
 ```
 
 - Create an Azure File Share with `cntk_sample` folder and upload the scripts into it:
@@ -62,7 +62,7 @@ The job creation parameters are in [job.json](./job.json):
 - stdOutErrPathPrefix specifies that the job should use file share for standard output and input;
 - An output directory with ID `MODEL` to allow job to find the output directory for the model via `$AZ_BATCHAI_OUTPUT_MODEL` environment variable;
 - node_count defining how many nodes will be used for the job execution;
-- job preparation task will execute CIFA-10_data_prepare.sh script to download and preprocess CIFAR-10 dataset on local SSD (at $AZ_BATCHAI_JOB_TEMP);
+- job preparation task will execute CIFAR-10_data_prepare.sh script to download and preprocess CIFAR-10 dataset on local SSD (at $AZ_BATCHAI_JOB_TEMP);
 - path and parameters for running ConvNet_CIFAR10_DataAug_Distributed.py;
 - ```microsoft/cntk:2.1-gpu-python3.5-cuda8.0-cudnn6.0``` docker image will be used for job execution.
 


### PR DESCRIPTION
- CIFAR-10_data_prepare.sh was misspelled as CIFA-10_data_prepare.sh in some places. This caused errors if the user blindly followed the instructions for CNTK GPU Python Distributed recipe.

- In other less relevant places, fixed similar naming issues.