### PR TITLE
Adding configuration.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,5 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+recipes/configuration\.json


### PR DESCRIPTION
I think there is value in adding configuration.json to .gitignore. This will prevent anyone who forks the repo and creates a configuration file in the recipes folder from accidently checking their credentials into Github.