### PR TITLE
'async' is a reserved word in Python >= 3.7

### DIFF
--- a/recipes/PyTorch/PyTorch-GPU-Distributed-Gloo/mnist_trainer.py
+++ b/recipes/PyTorch/PyTorch-GPU-Distributed-Gloo/mnist_trainer.py
@@ -125,7 +125,7 @@ def train(epoch):
         # measure data loading time
         data_time.update(time.time() - end)
 
-        target = target.cuda(async=True)
+        target = target.cuda(non_blocking=True)
         input_var = torch.autograd.Variable(input)
         target_var = torch.autograd.Variable(target)
 


### PR DESCRIPTION
__async__ is a reserved word in Python 3.7 and later.  To fix this pytorch/pytorch#4999 changed __cuda(async=True)__ to __cuda(non_blocking=True)__ so this PR tracks with that change.  That fix landed in PyTourch 0.4.1.